### PR TITLE
added printer and represent return the representation of the op

### DIFF
--- a/core/include/operation.h
+++ b/core/include/operation.h
@@ -3,6 +3,7 @@
 #define OPERATION_H_
 #include <unordered_set>
 #include <string>
+#include "printer.h"
 #include "sdgraph.h"
 #include "global.h"
 #include "exception.h"
@@ -32,11 +33,13 @@ public:
     element() = default;
     element(operation * op);
     virtual ~element(){}
-    virtual void represent(std::ostream &os, context *ctx){
-        os<<"%";
-        if(traceID > -1) os<<traceID;
-        else os<<"Unknown";
-        os<<" <"<<tid<<">";
+    virtual std::string represent(context *ctx){
+        printer p;
+        p.addString("%");
+        std::string id = traceID > -1 ? std::to_string(traceID) :"Unknown";
+        p.addString(id);
+        p.addToken("<"+tid+">");
+        return p.getString();
     }
     operation* getDefiningOp();
     std::vector<operation*> getUsers();
@@ -53,11 +56,10 @@ public :
     virtual ~operation(){
         inputElements.clear();
     }
-    virtual void represent(std::ostream &os, context *ctx) = 0;
+    virtual std::string represent(context *ctx) = 0;
     virtual void printOp(context *ctx){
         printIndent(ctx);
-        Xos<<getID()<<" : ";
-        represent(Xos, ctx);
+        Xos<<getID()<<" : "<<represent(ctx);
         Xos<<"\n";
     }
     void print(context *ctx);
@@ -109,11 +111,11 @@ public:
     moduleOp();
     ~moduleOp(){std::cout<<"deleted"<<std::endl;}
     region* getRegion(){return &block;}
-    void represent(std::ostream &os, context *ctx);
+    std::string represent(context *ctx){return getTypeID();}
     virtual void printOp(context *ctx) override final{
         printIndent(ctx);
         Xos<<getTypeID()<<" : ";
-        represent(Xos, ctx);
+        block.printRegion(ctx);
         Xos<<"\n";
     }
     region block;
@@ -145,8 +147,6 @@ public :
     region * _region = nullptr;
     moduleOp * op;
 };
-
-
 
 }
 

--- a/core/include/ops.h
+++ b/core/include/ops.h
@@ -15,8 +15,10 @@ public:
         setTypeID("Def");
     }
     element* output(){return &(elements[0]);}
-    void represent(std::ostream &os, context *ctx){
-        output()->represent(os,ctx);
+    std::string represent(context *ctx) final{
+        printer p;
+        p.addToken(output()->represent(ctx));
+        return p.getString();
     }
 };
 class addOp : public operation{
@@ -29,12 +31,14 @@ class addOp : public operation{
     element* lhs(){return inputElements[0];}
     element* rhs(){return inputElements[1];}
     element* output(){return &(elements[0]);}
-    void represent(std::ostream &os, context *ctx){
-        output()->represent(os, ctx);
-        os<<" = ";
-        lhs()->represent(os, ctx);
-        os<<" + ";
-        rhs()->represent(os, ctx);
+    std::string represent(context *ctx) final {
+        printer p;
+        p.addToken(output()->represent(ctx));
+        p.addToken("=");
+        p.addToken(lhs()->represent(ctx));
+        p.addToken("+");
+        p.addToken(rhs()->represent(ctx));
+        return p.getString();
     }
 };
 
@@ -48,18 +52,19 @@ class multiplyOp : public operation {
     element* lhs(){return inputElements[0];}
     element* rhs(){return inputElements[1];}
     element* output(){return &(elements[0]);}
-    void represent(std::ostream &os, context *ctx){
-        output()->represent(os,ctx);
-        os<<" = ";
-        lhs()->represent(os, ctx);
-        os<<" * ";
-        rhs()->represent(os, ctx);
+    std::string represent(context *ctx) final{
+        printer p;
+        p.addToken(output()->represent(ctx));
+        p.addToken("=");
+        p.addToken(lhs()->represent(ctx));
+        p.addToken("*");
+        p.addToken(rhs()->represent(ctx));
+        return p.getString();
     }
 };
 
 class sumOp : public operation, public opGroup<commutable>{
     public:
-
     template <typename... ARGS>
     sumOp(ARGS *...args) {
         acceptInput(args...);
@@ -73,15 +78,17 @@ class sumOp : public operation, public opGroup<commutable>{
     }
     element* output(){return &(elements[0]);}
 
-    void represent(std::ostream &os, context *ctx){
-        output()->represent(os,ctx);
-        os<<" = ";
+    std::string represent(context *ctx) final {
+        printer p;
+        p.addToken(output()->represent(ctx));
+        p.addToken("=");
         int n = inputElements.size(), i=0;
         for(auto e : inputElements){
-            e->represent(os, ctx);
+            p.addToken(e->represent(ctx));
             i++;
-            if(i!= n) os<<" + ";
+            if(i!= n) p.addToken("+");
         }
+        return p.getString();
     }
 };
 }

--- a/core/include/printer.h
+++ b/core/include/printer.h
@@ -1,0 +1,22 @@
+#ifndef PRINTER_H
+#define PRINTER_H
+#include <string>
+
+class printer {
+    public :
+    printer () = default;
+    std::string getString(){
+        return buffer;
+    }
+    void flush(){buffer ="";}
+    void addToken(std::string tok){
+        if(buffer.empty()) buffer = tok;
+        else buffer = buffer+" "+tok;
+    }
+    void addString(std::string str){
+        buffer = buffer+str;
+    }
+    std::string buffer;
+};
+
+#endif

--- a/core/src/operation.cpp
+++ b/core/src/operation.cpp
@@ -67,8 +67,5 @@ inline void region::printOps(context *ctx){
 
 moduleOp::moduleOp(){
     setTypeID("module");
-    block.getEntry().hasOutput();  
-} 
-void moduleOp::represent(std::ostream &os, context *ctx){
-    block.printRegion(ctx);
+    block.getEntry().hasOutput();
 }


### PR DESCRIPTION
The represent from ops are play the role as encode of the ops. The representation should be enough to create the original op. 
issue #10 